### PR TITLE
Changed Techstack Images to Static Import

### DIFF
--- a/src/data/techstack.ts
+++ b/src/data/techstack.ts
@@ -1,11 +1,19 @@
-const techStack = [
-  { image: "/techstack/python.webp", link: "https://www.python.org" },
-  { image: "/techstack/pandas.webp", link: "https://pandas.pydata.org/" },
-  { image: "/techstack/stata.webp", link: "https://www.stata.com/" },
-  { image: "/techstack/tailwind.webp", link: "https://tailwindcss.com" },
-  { image: "/techstack/flask.webp", link: "https://flask.palletsprojects.com" },
-  { image: "/techstack/ocaml.webp", link: "https://ocaml.org/" },
-  { image: "/techstack/numpy.webp", link: "https://numpy.org" },
+import PythonLogo from "@/public/techstack/python.webp";
+import PandasLogo from "@/public/techstack/pandas.webp";
+import StataLogo from "@/public/techstack/stata.webp";
+import TailwindLogo from "@/public/techstack/tailwind.webp";
+import FlaskLogo from "@/public/techstack/flask.webp";
+import OcamlLogo from "@/public/techstack/ocaml.webp";
+import NumpyLogo from "@/public/techstack/numpy.webp";
+
+const TechStack = [
+  { image: PythonLogo, link: "https://www.python.org" },
+  { image: PandasLogo, link: "https://pandas.pydata.org/" },
+  { image: StataLogo, link: "https://www.stata.com/" },
+  { image: TailwindLogo, link: "https://tailwindcss.com" },
+  { image: FlaskLogo, link: "https://flask.palletsprojects.com" },
+  { image: OcamlLogo, link: "https://ocaml.org/" },
+  { image: NumpyLogo, link: "https://numpy.org" },
 ];
 
-export default techStack;
+export default TechStack;


### PR DESCRIPTION
Techstack Images now have static import:
![image](https://github.com/user-attachments/assets/92a53015-acc8-426a-8ef6-4c0cdda87856)
similar to the board-component from deployment:

![image](https://github.com/user-attachments/assets/27d5bb09-c1c7-459a-a89d-e54cc3591b43)
Tested in local to make sure they still work:
![image](https://github.com/user-attachments/assets/0fe51342-aadd-4295-99de-01bfa3693429)
