### PR TITLE
Fix x overflow in boards animation

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -20,7 +20,7 @@ const Board = () => {
         animate={{ opacity: 1, scale: 1 }}
         transition={{
           duration: 0.1,
-          scale: { type: "spring", damping: 10, stiffness: 100 },
+          scale: { damping: 10, stiffness: 100 },
         }}
       >
         <Boards />


### PR DESCRIPTION
no longer overflows on the x axis for a second when loading the page

the error was due to the spring variant, which enlarges the content for a bit before bringing it back down