### PR TITLE
Responsified event components

### DIFF
--- a/src/components/events/event.tsx
+++ b/src/components/events/event.tsx
@@ -52,7 +52,7 @@ const EventCard = ({
                 {title}
               </div>
               <button
-                onClick={() => setIsExpanded(!isExpanded)}
+                onClick={() => setIsExpanded((prev) => !prev)}
                 className="rounded-full p-2 text-quant-blue-100 transition hover:bg-white/20 sm:hidden"
               >
                 {isExpanded ? <Minus size={20} /> : <Plus size={20} />}

--- a/src/components/events/event.tsx
+++ b/src/components/events/event.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 import LocationIcon from "@/public/icons/LocationIconBlue.svg";
 import TimeIcon from "@/public/icons/timeIcon.svg";
 import TimeIconMobile from "@/public/icons/TimeIconMobile.svg";
+import { useState } from "react";
+import { Plus, Minus } from "lucide-react";
 
 type EventCardProps = {
   day: string;
@@ -10,6 +12,7 @@ type EventCardProps = {
   location: string;
   time: string;
   description: string;
+  isInitiallyExpanded: boolean;
 };
 const EventCard = ({
   day,
@@ -18,10 +21,12 @@ const EventCard = ({
   location,
   time,
   description,
+  isInitiallyExpanded,
 }: EventCardProps) => {
+  const [isExpanded, setIsExpanded] = useState(isInitiallyExpanded);
   return (
     <div className="flex w-11/12 items-center gap-6 rounded-3xl bg-[#FFFFFF61] p-4 sm:h-1/3 sm:w-4/5 sm:pb-12 lg:h-1/3 lg:w-3/4">
-      <div className="mb-20 hidden sm:mb-0 sm:flex sm:h-full sm:w-4/5 sm:flex-col sm:items-center sm:justify-start sm:pt-7 lg:h-full lg:w-1/5 lg:items-center lg:justify-center lg:pt-3">
+      <div className="mb-20 hidden sm:mb-0 sm:flex sm:h-full sm:w-1/5 sm:flex-col sm:items-center sm:justify-start sm:pt-7 lg:h-full lg:w-1/5 lg:items-center lg:justify-center lg:pt-3">
         <div className="text-center font-questrial text-base uppercase text-[#DDF0FE] sm:text-left sm:text-2xl sm:text-quant-blue-100 lg:text-center lg:text-xl">
           {day}
         </div>
@@ -29,7 +34,7 @@ const EventCard = ({
           {date}
         </div>
       </div>
-      <div className="flex flex-col sm:h-full lg:h-full lg:w-4/5">
+      <div className="flex w-full flex-col sm:h-full lg:h-full">
         <div className="flex gap-5">
           <div className="sm:hidden">
             <div className="text-center font-questrial text-base uppercase text-[#DDF0FE]">
@@ -39,49 +44,52 @@ const EventCard = ({
               {date}
             </div>
           </div>
-          <div className="sm:w-2/3">
-            <div className="justify-start pb-1 font-questrial text-xl font-medium text-quant-white sm:pb-0 sm:pt-10 sm:text-3xl lg:pl-10 lg:text-4xl">
-              {title}
+          <div className="w-full">
+            <div className="flex flex-row justify-between">
+              <div className="mb-1 justify-start font-questrial text-xl font-bold text-quant-white sm:pb-0 sm:pt-10 sm:text-2xl lg:text-3xl">
+                {title}
+              </div>
+              <button
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="rounded-full p-2 text-quant-blue-100 transition hover:bg-white/20 sm:hidden"
+              >
+                {isExpanded ? <Minus size={20} /> : <Plus size={20} />}
+              </button>
             </div>
-            <div className="lg:h-2/8 mt-1 flex flex-row gap-3 sm:mt-0 sm:gap-20 lg:w-2/3 lg:pl-8">
-              <div className="h-1/8 flex w-1/5 flex-row gap-2 pl-1 font-roboto text-quant-blue-100 sm:text-lg">
+            <div className="lg:h-2/8 mt-1 flex w-fit flex-row gap-3 sm:mt-0 sm:gap-5">
+              <div className="flex w-fit flex-row items-center gap-2 font-roboto text-quant-blue-100">
                 <Image
                   src={LocationIcon}
                   alt="Location Icon"
-                  width={24}
-                  height={24}
-                  className="h-3/5 sm:mt-1 sm:h-4/5"
+                  className="h-5 w-5 sm:h-6 sm:w-6 md:h-7 md:w-7"
                 />
-                <div className="-translate-y-[1px] text-xs sm:-translate-y-0 sm:text-lg lg:flex lg:items-center">
-                  {location}
-                </div>
+                <div className="text-base sm:text-lg">{location}</div>
               </div>
-              <div className="h-7/8 flex flex-row gap-2 pl-10 font-roboto text-sm text-quant-blue-100 sm:translate-x-12 sm:text-lg md:-translate-x-10 lg:-translate-x-0">
+              <div className="h-7/8 flex w-fit flex-row items-center gap-2 font-roboto">
                 <Image
                   src={TimeIconMobile}
                   alt="Time Icon"
-                  width={24}
-                  height={24}
-                  className="h-3/5 -translate-x-4 sm:hidden sm:-translate-x-0"
+                  className="h-5 w-5 sm:hidden"
                 />
                 <Image
                   src={TimeIcon}
                   alt="Time Icon"
-                  width={24}
-                  height={24}
-                  className="hidden sm:block"
+                  className="hidden sm:block sm:h-6 sm:w-6 md:h-7 md:w-7"
                 />
-                <div className="-translate-x-5 -translate-y-[1px] text-xs sm:-translate-x-0 sm:-translate-y-0 sm:text-lg">
+
+                <div className="text-base text-quant-blue-100 sm:text-lg">
                   {time}
                 </div>
               </div>
             </div>
-            <div className="pt-2 text-xs text-[#BDBDBD] sm:hidden">
-              {description}
-            </div>
+            {isExpanded && (
+              <div className="mt-2 text-xs text-[#BDBDBD] transition-opacity duration-300 sm:hidden">
+                {description}
+              </div>
+            )}
           </div>
         </div>
-        <div className="sm:w-5/7 hidden pt-3 font-roboto text-xs text-quant-gray sm:flex sm:h-full sm:pt-3 sm:text-lg lg:h-full lg:w-5/6 lg:pl-10 lg:pt-2">
+        <div className="sm:w-5/7 hidden pt-3 font-roboto text-xs text-quant-gray sm:flex sm:h-full sm:pt-3 sm:text-base lg:h-full lg:w-5/6 lg:pt-2">
           {description}
         </div>
       </div>

--- a/src/components/events/event.tsx
+++ b/src/components/events/event.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import LocationIcon from "@/public/icons/LocationIconBlue.svg";
 import TimeIcon from "@/public/icons/timeIcon.svg";

--- a/src/components/events/events.tsx
+++ b/src/components/events/events.tsx
@@ -28,7 +28,6 @@ const fetchEvents = async (): Promise<EventProps[]> => {
     }/events?key=${process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_API_KEY}
         &singleEvents=true&orderBy=startTime&timeMin=${new Date().toISOString()}`,
   );
-
   if (!response.ok) {
     throw new Error("Error fetching events");
   }
@@ -99,6 +98,7 @@ const Events = () => {
             location={location}
             time={time}
             description={description}
+            isInitiallyExpanded={index === 0}
           />
         </div>
       ))}


### PR DESCRIPTION
Responsified the event component for ipad,phone,dekstop:

![chrome-capture-2025-3-5](https://github.com/user-attachments/assets/2aa0a5ab-1578-4433-8582-09a816470509)

Desktop:

<img width="1512" alt="Screenshot 2025-03-05 at 3 07 02 PM" src="https://github.com/user-attachments/assets/8df5ccd5-75ec-4f60-890f-55f4cd4cd27d" />

Ipad:

<img width="1259" alt="Screenshot 2025-03-05 at 3 08 19 PM" src="https://github.com/user-attachments/assets/8d549100-ac7e-4907-b96b-597dc53c4e5d" />

Iphone:

<img width="1259" alt="Screenshot 2025-03-05 at 3 08 32 PM" src="https://github.com/user-attachments/assets/b7a3b496-9f3b-40b0-8c34-30d359ce3d73" />